### PR TITLE
Disable versioned_symbols test

### DIFF
--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -12,7 +12,7 @@ override_dh_auto_configure:
 
 
 override_dh_auto_test-arch:
-	LD_LIBRARY_PATH=$(CURDIR)/obj-$(DEB_HOST_GNU_TYPE)/src LC_ALL=C dh_auto_test
+	LD_LIBRARY_PATH=$(CURDIR)/obj-$(DEB_HOST_GNU_TYPE)/src LC_ALL=C dh_auto_test -- ARGS="-E INTEGRATION_versioned_symbols"
 
 execute_after_dh_auto_build-indep:
 	dh_auto_build -- doc  # Generate documentation


### PR DESCRIPTION
Nightly builds and a prerelease have been failing due to the `INTEGRATION_versioned_symbols` test failing since https://github.com/gazebosim/sdformat/pull/1414 was merged forward to `main` / `sdf15` in https://github.com/gazebosim/sdformat/pull/1470. Strangely, the test only fails in these debbuilds. So just disable the test for now.

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat15-debbuilder&build=518)](https://build.osrfoundation.org/view/gz-ionic/job/sdformat15-debbuilder/518/) https://build.osrfoundation.org/view/gz-ionic/job/sdformat15-debbuilder/518/

~~~
255: Test command: /usr/bin/bash "/home/jenkins/workspace/sdformat15-debbuilder/build/sdformat/obj-x86_64-linux-gnu/test/integration/all_symbols_have_version.bash" "/home/jenkins/workspace/sdformat15-debbuilder/build/sdformat/obj-x86_64-linux-gnu/lib/libsdformat15.so.15.0.0"
255: Working Directory: /home/jenkins/workspace/sdformat15-debbuilder/build/sdformat/obj-x86_64-linux-gnu/test/integration
255: Test timeout computed to be: 1500
255: ERROR: Found unversioned symbols:\n00000000017b6f90 N sdformat15_get_install_prefix_impl.cc.901ddfbe
Test #255: INTEGRATION_versioned_symbols ..........................***Failed    0.13 sec
~~~